### PR TITLE
Fix Ruby 2.7 Warning

### DIFF
--- a/lib/process/pipeline/step.rb
+++ b/lib/process/pipeline/step.rb
@@ -96,7 +96,7 @@ module Process
 			def each_line(*args, &block)
 				return to_enum(:each_line, *args) unless block_given?
 				
-				read(*args) do |output|
+				read(**args[0]) do |output|
 					output.each_line(&block)
 				end
 			end

--- a/process-pipeline.gemspec
+++ b/process-pipeline.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
 	spec.add_dependency "process-group"
 
-	spec.add_development_dependency "bundler", "~> 1.15"
+	spec.add_development_dependency "bundler", "~> 2.1.2"
 	spec.add_development_dependency "rake", "~> 10.0"
 	spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/process-pipeline.gemspec
+++ b/process-pipeline.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
 	spec.add_dependency "process-group"
 
-	spec.add_development_dependency "bundler", "~> 2.1.2"
+	spec.add_development_dependency "bundler"
 	spec.add_development_dependency "rake", "~> 10.0"
 	spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/spec/process/pipeline_spec.rb
+++ b/spec/process/pipeline_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Process::Pipeline do
 
 		output, input = IO.pipe
 
-		thread = Thread.new do
+		Thread.new do
 			%w{the quick brown fox jumps over the lazy dog}.each do |word|
 				input.puts word
 			end


### PR DESCRIPTION
warning: Using the last argument as keyword parameters is deprecated